### PR TITLE
Allow Listing from Storage Options

### DIFF
--- a/intake_pattern_catalog/catalog.py
+++ b/intake_pattern_catalog/catalog.py
@@ -46,6 +46,11 @@ class PatternCatalog(Catalog):
             Whether or not to construct a list of all the matching entries when the
             catalog is instantiated
         """
+        if urlpath == "reference://"
+            urlpath = kwargs['storage_options']['fo']
+            self.reference = True
+        else:
+            self.reference = False
         self.urlpath = PatternCatalog._trim_prefix(urlpath)
         self.urlpath_with_fsspec_prefix = urlpath
         self.text = None
@@ -101,15 +106,21 @@ class PatternCatalog(Catalog):
             urlpath = self.get_entry_path(**kwargs)
             if self._exists(urlpath) is False:
                 raise KeyError(f"{urlpath} not found")
+
+            so = self.storage_options
+            if self.reference: 
+                so['fo'] = urlpath
+                so = storage_options
+
             entry = _local_catalog_entry(
                 name=name,
-                urlpath=urlpath,
+                urlpath=urlpath if not self.reference else "reference://",
                 description=self.description,
                 filesystem=self.filesystem,
                 driver=self.driver,
                 metadata=self.metadata,
                 driver_kwargs=self.driver_kwargs,
-                storage_options=self.storage_options,
+                storage_options=so,
             )
             self._entries[name] = entry
             self._kwarg_sets.append(kwargs)
@@ -154,15 +165,21 @@ class PatternCatalog(Catalog):
                 self._kwarg_sets.append(value_map)
                 urlpath = self.get_entry_path(**value_map)
                 name = PatternCatalog._entry_name(value_map)
+
+                so = self.storage_options
+                if self.reference: 
+                    so['fo'] = urlpath
+                    so = storage_options
+
                 entry = _local_catalog_entry(
                     name=name,
-                    urlpath=urlpath,
+                    urlpath=urlpath if not self.reference else "reference://",
                     description=self.description,
                     filesystem=self.filesystem,
                     driver=self.driver,
                     metadata=self.metadata,
                     driver_kwargs=self.driver_kwargs,
-                    storage_options=self.storage_options,
+                    storage_options=so,
                 )
                 if entry.name in self._entries:
                     warnings.warn(

--- a/intake_pattern_catalog/catalog.py
+++ b/intake_pattern_catalog/catalog.py
@@ -110,7 +110,6 @@ class PatternCatalog(Catalog):
             so = self.storage_options
             if self.reference: 
                 so['fo'] = urlpath
-                so = storage_options
 
             entry = _local_catalog_entry(
                 name=name,
@@ -169,7 +168,6 @@ class PatternCatalog(Catalog):
                 so = self.storage_options
                 if self.reference: 
                     so['fo'] = urlpath
-                    so = storage_options
 
                 entry = _local_catalog_entry(
                     name=name,

--- a/intake_pattern_catalog/catalog.py
+++ b/intake_pattern_catalog/catalog.py
@@ -46,7 +46,7 @@ class PatternCatalog(Catalog):
             Whether or not to construct a list of all the matching entries when the
             catalog is instantiated
         """
-        if urlpath == "reference://"
+        if urlpath == "reference://":
             urlpath = kwargs['storage_options']['fo']
             self.reference = True
         else:

--- a/intake_pattern_catalog/catalog.py
+++ b/intake_pattern_catalog/catalog.py
@@ -47,7 +47,7 @@ class PatternCatalog(Catalog):
             catalog is instantiated
         """
         if urlpath == "reference://":
-            urlpath = kwargs['storage_options']['fo']
+            urlpath = kwargs["storage_options"]["fo"]
             self.reference = True
         else:
             self.reference = False
@@ -108,8 +108,8 @@ class PatternCatalog(Catalog):
                 raise KeyError(f"{urlpath} not found")
 
             so = self.storage_options
-            if self.reference: 
-                so['fo'] = urlpath
+            if self.reference:
+                so["fo"] = urlpath
 
             entry = _local_catalog_entry(
                 name=name,
@@ -166,8 +166,8 @@ class PatternCatalog(Catalog):
                 name = PatternCatalog._entry_name(value_map)
 
                 so = self.storage_options
-                if self.reference: 
-                    so['fo'] = urlpath
+                if self.reference:
+                    so["fo"] = urlpath
 
                 entry = _local_catalog_entry(
                     name=name,

--- a/tests/test_pattern_catalog.py
+++ b/tests/test_pattern_catalog.py
@@ -343,7 +343,10 @@ def test_globbed_files(tmp_path):
 
 
 def test_kerchunk_reference_files(folder_with_csvs: str):
-    """this tests whether pattern catalog will list from storage_options['fo'] when url = reference://"""
+    """
+    This tests whether pattern catalog will list from 
+    storage_options['fo'] when url = reference://
+    """
     cat = PatternCatalog(
         name="catalog_to_transform",
         urlpath="reference://",

--- a/tests/test_pattern_catalog.py
+++ b/tests/test_pattern_catalog.py
@@ -340,3 +340,17 @@ def test_globbed_files(tmp_path):
         .read()
     )
     assert len(globbed_df) == 4
+
+
+def test_kerchunk_reference_files(folder_with_csvs: str):
+    """this tests whether pattern catalog will list from storage_options['fo'] when url = reference://"""
+    cat = PatternCatalog(
+        name="catalog_to_transform",
+        urlpath="reference://",
+        driver="csv",
+        listable=True,
+        storage_options={'fo': str(Path(folder_with_csvs, "{num}.csv"))}
+    )
+
+    # Make sure I can access a valid entry without error
+    assert cat.get_entry(num=1)

--- a/tests/test_pattern_catalog.py
+++ b/tests/test_pattern_catalog.py
@@ -344,7 +344,7 @@ def test_globbed_files(tmp_path):
 
 def test_kerchunk_reference_files(folder_with_csvs: str):
     """
-    This tests whether pattern catalog will list from 
+    This tests whether pattern catalog will list from
     storage_options['fo'] when url = reference://
     """
     cat = PatternCatalog(
@@ -352,7 +352,7 @@ def test_kerchunk_reference_files(folder_with_csvs: str):
         urlpath="reference://",
         driver="csv",
         listable=True,
-        storage_options={'fo': str(Path(folder_with_csvs, "{num}.csv"))}
+        storage_options={"fo": str(Path(folder_with_csvs, "{num}.csv"))},
     )
 
     # Make sure I can access a valid entry without error


### PR DESCRIPTION
Intake entries for Kerchunk reference files have a different layout to normal intake entries:

```
metadata:
  version: 1
sources:
    pattern_test:
        description: Stuff and things
        driver: pattern_cat
        args:
          driver: intake_xarray.xzarr.ZarrSource
          listable: True
          urlpath: "reference://"
          storage_options:
              fo: '/home/pmarsh/ERA5_Kerchunk/references/{step}/{var}.json'
```

This PR modifies intake-pattern-catalog to fall back to using `['storage_options']['fo']` when the urlpath is `'reference://`

I have added a short test which only checks this behaviour nothing more. 